### PR TITLE
BUG: DBPN3D was not generalizable

### DIFF
--- a/R/createDeepBackProjectionNetworkModel.R
+++ b/R/createDeepBackProjectionNetworkModel.R
@@ -40,8 +40,6 @@
 #' \code{strides = c( 8, 8 )}. We default to 8x parameters.
 #' @param lastConvolution the kernel size for the last convolutional layer
 #' @param numberOfLossFunctions the number of data targets, e.g. 2 for 2 targets
-#' @param doFeatureSmashing if this is \code{FALSE}, then
-#' \code{numberOfBaseFilters} should equal \code{numberOfFeatureFilters}.
 #'
 #' @return a keras model defining the deep back-projection network.
 #' @author Tustison NJ
@@ -61,16 +59,12 @@ createDeepBackProjectionNetworkModel2D <-
                                convolutionKernelSize = c( 12, 12 ),
                                strides = c( 8, 8 ),
                                lastConvolution = c( 3, 3 ),
-                               numberOfLossFunctions = 1,
-                               doFeatureSmashing = TRUE
+                               numberOfLossFunctions = 1
                              )
 {
-  if ( ! doFeatureSmashing & ( numberOfFeatureFilters != numberOfBaseFilters ) )
-    stop( paste("if not doFeatureSmashing == FALSE, then numberOfFeatureFilters
-    should equal numberOfBaseFilters.") )
 
   upBlock2D <- function( L, numberOfFilters = 64, kernelSize = c( 12, 12 ),
-    strides = c( 8, 8 ), includeDenseConvolutionLayer = FALSE )
+    strides = c( 8, 8 ), includeDenseConvolutionLayer = TRUE )
     {
     if( includeDenseConvolutionLayer )
       {
@@ -111,7 +105,7 @@ createDeepBackProjectionNetworkModel2D <-
     }
 
   downBlock2D <- function( H, numberOfFilters = 64, kernelSize = c( 12, 12 ),
-    strides = c( 8, 8 ), includeDenseConvolutionLayer = FALSE )
+    strides = c( 8, 8 ), includeDenseConvolutionLayer = TRUE )
     {
     if( includeDenseConvolutionLayer )
       {
@@ -161,6 +155,7 @@ createDeepBackProjectionNetworkModel2D <-
     shared_axes = c( 1, 2 ) )
 
   # Feature smashing
+  doFeatureSmashing = TRUE
   if ( doFeatureSmashing ) {
     model <- model %>% layer_conv_2d( filters = numberOfBaseFilters,
       kernel_size = c( 1, 1 ), strides = c( 1, 1 ), padding = 'same',
@@ -266,8 +261,6 @@ createDeepBackProjectionNetworkModel2D <-
 #' 8x --> \code{strides = c( 8, 8, 8 )}. We default to 8x parameters.
 #' @param lastConvolution the kernel size for the last convolutional layer
 #' @param numberOfLossFunctions the number of data targets, e.g. 2 for 2 targets
-#' @param doFeatureSmashing if this is \code{FALSE}, then
-#' \code{numberOfBaseFilters} should equal \code{numberOfFeatureFilters}.
 #'
 #' @return a keras model defining the deep back-projection network.
 #' @author Tustison NJ
@@ -287,16 +280,12 @@ createDeepBackProjectionNetworkModel3D <-
                                convolutionKernelSize = c( 12, 12, 12 ),
                                strides = c( 8, 8, 8 ),
                                lastConvolution = c( 3, 3, 3 ),
-                               numberOfLossFunctions = 1,
-                               doFeatureSmashing = TRUE
+                               numberOfLossFunctions = 1
                              )
 {
-  if ( ! doFeatureSmashing & ( numberOfFeatureFilters != numberOfBaseFilters ) )
-    stop( paste("if not doFeatureSmashing == FALSE, then numberOfFeatureFilters
-    should equal numberOfBaseFilters.") )
 
   upBlock3D <- function( L, numberOfFilters = 64, kernelSize = c( 12, 12, 12 ),
-    strides = c( 8, 8, 8 ), includeDenseConvolutionLayer = FALSE )
+    strides = c( 8, 8, 8 ), includeDenseConvolutionLayer = TRUE )
     {
     if( includeDenseConvolutionLayer )
       {
@@ -337,7 +326,7 @@ createDeepBackProjectionNetworkModel3D <-
     }
 
   downBlock3D <- function( H, numberOfFilters = 64, kernelSize = c( 12, 12, 12 ),
-    strides = c( 8, 8, 8 ), includeDenseConvolutionLayer = FALSE )
+    strides = c( 8, 8, 8 ), includeDenseConvolutionLayer = TRUE )
     {
     if( includeDenseConvolutionLayer )
       {
@@ -387,6 +376,7 @@ createDeepBackProjectionNetworkModel3D <-
     shared_axes = c( 1, 2, 3 ) )
 
   # Feature smashing
+  doFeatureSmashing = TRUE
   if ( doFeatureSmashing ) {
     model <- model %>% layer_conv_3d( filters = numberOfBaseFilters,
       kernel_size = c( 1, 1, 1 ), strides = c( 1, 1, 1 ), padding = 'same',
@@ -402,7 +392,6 @@ createDeepBackProjectionNetworkModel3D <-
   model <- upBlock3D( model, numberOfFilters = numberOfBaseFilters,
     kernelSize = convolutionKernelSize, strides = strides )
   upProjectionBlocks[[1]] <- model
-  model <- layer_concatenate( upProjectionBlocks )
 
   for( i in seq_len( numberOfBackProjectionStages ) )
     {
@@ -411,7 +400,6 @@ createDeepBackProjectionNetworkModel3D <-
       model <- downBlock3D( model, numberOfFilters = numberOfBaseFilters,
         kernelSize = convolutionKernelSize, strides = strides )
       downProjectionBlocks[[i]] <- model
-      model <- layer_concatenate( downProjectionBlocks )
 
       model <- upBlock3D( model, numberOfFilters = numberOfBaseFilters,
         kernelSize = convolutionKernelSize, strides = strides )

--- a/man/createDeepBackProjectionNetworkModel2D.Rd
+++ b/man/createDeepBackProjectionNetworkModel2D.Rd
@@ -8,8 +8,7 @@ createDeepBackProjectionNetworkModel2D(inputImageSize,
   numberOfOutputs = 1, numberOfBaseFilters = 64,
   numberOfFeatureFilters = 256, numberOfBackProjectionStages = 7,
   convolutionKernelSize = c(12, 12), strides = c(8, 8),
-  lastConvolution = c(3, 3), numberOfLossFunctions = 1,
-  doFeatureSmashing = TRUE)
+  lastConvolution = c(3, 3), numberOfLossFunctions = 1)
 }
 \arguments{
 \item{inputImageSize}{Used for specifying the input tensor shape.  The
@@ -41,9 +40,6 @@ original paper.  Factors used in the original implementation are as follows:
 \item{lastConvolution}{the kernel size for the last convolutional layer}
 
 \item{numberOfLossFunctions}{the number of data targets, e.g. 2 for 2 targets}
-
-\item{doFeatureSmashing}{if this is \code{FALSE}, then
-\code{numberOfBaseFilters} should equal \code{numberOfFeatureFilters}.}
 }
 \value{
 a keras model defining the deep back-projection network.

--- a/man/createDeepBackProjectionNetworkModel3D.Rd
+++ b/man/createDeepBackProjectionNetworkModel3D.Rd
@@ -8,8 +8,7 @@ createDeepBackProjectionNetworkModel3D(inputImageSize,
   numberOfOutputs = 1, numberOfBaseFilters = 64,
   numberOfFeatureFilters = 256, numberOfBackProjectionStages = 7,
   convolutionKernelSize = c(12, 12, 12), strides = c(8, 8, 8),
-  lastConvolution = c(3, 3, 3), numberOfLossFunctions = 1,
-  doFeatureSmashing = TRUE)
+  lastConvolution = c(3, 3, 3), numberOfLossFunctions = 1)
 }
 \arguments{
 \item{inputImageSize}{Used for specifying the input tensor shape.  The
@@ -41,9 +40,6 @@ original paper.  Factors used in the original implementation are as follows:
 \item{lastConvolution}{the kernel size for the last convolutional layer}
 
 \item{numberOfLossFunctions}{the number of data targets, e.g. 2 for 2 targets}
-
-\item{doFeatureSmashing}{if this is \code{FALSE}, then
-\code{numberOfBaseFilters} should equal \code{numberOfFeatureFilters}.}
 }
 \value{
 a keras model defining the deep back-projection network.


### PR DESCRIPTION

address the issue below + another bug and remove some temporary options that are no longer necessary.

```
library( tensorflow )
library( ANTsRNet )

m2=createDeepBackProjectionNetworkModel2D( list(24,24, 1 ) )
m2b=createDeepBackProjectionNetworkModel2D( list(NULL,NULL, 1 ) )

m3=createDeepBackProjectionNetworkModel3D( list(24,24,24, 1 ),
  convolutionKernelSize = c(3,3,3), strides=c(2,2,2) )
m3b=createDeepBackProjectionNetworkModel3D( list(NULL,NULL,NULL, 1 ),
    convolutionKernelSize = c(3,3,3), strides=c(2,2,2) )
dd = c( 1, 12, 12, 12, 1 )
myarr = array( rnorm( prod(dd) ), dim = dd )
ee = c( 1, 16, 16, 16, 1 )
myarr2 = array( rnorm( prod(ee) ), dim = ee )
p1=predict( m3b, myarr )
p2=predict( m3b, myarr2 )
```