### PR TITLE
ENH: Check for existing data files before using keras to download.

### DIFF
--- a/R/getANTsXNetData.R
+++ b/R/getANTsXNetData.R
@@ -52,7 +52,7 @@ getANTsXNetData <- function(
   if( fileId[1] == "show" )
     {
     return( fileId )
-   }
+    }
   fileId = match.arg( fileId )
 
   url <- switch(
@@ -91,6 +91,24 @@ getANTsXNetData <- function(
   if( is.null( antsxnetCacheDirectory ) )
     {
     antsxnetCacheDirectory <- "ANTsXNet"
+    }
+
+  targetFileNamePath <- ""
+
+  # Check if file exists before involving keras, which requires a writeable cache directory
+  # Checking first allows singularity containers to use internal data
+  if (fs::is_absolute_path(antsxnetCacheDirectory))
+    {
+    targetFileNamePath <- fs::path_join(c(antsxnetCacheDirectory, targetFileName))
+    }
+  else
+    {
+    targetFileNamePath <- fs::path_join(c("~/.keras", antsxnetCacheDirectory, targetFileName))
+    }
+
+  if (fs::file_exists(targetFileNamePath))
+    {
+    return(targetFileNamePath)
     }
 
   targetFileNamePath <- tensorflow::tf$keras$utils$get_file(

--- a/R/getPretrainedNetwork.R
+++ b/R/getPretrainedNetwork.R
@@ -221,6 +221,25 @@ getPretrainedNetwork <- function(
     {
     antsxnetCacheDirectory <- "ANTsXNet"
     }
+
+  targetFileNamePath <- ""
+
+  # Check if file exists before involving keras, which requires a writeable cache directory
+  # Checking first allows singularity containers to use internal data
+  if (fs::is_absolute_path(antsxnetCacheDirectory))
+    {
+    targetFileNamePath <- fs::path_join(c(antsxnetCacheDirectory, targetFileName))
+    }
+  else
+    {
+    targetFileNamePath <- fs::path_join(c("~/.keras", antsxnetCacheDirectory, targetFileName))
+    }
+
+  if (fs::file_exists(targetFileNamePath))
+    {
+    return(targetFileNamePath)
+    }
+
   targetFileNamePath <- tensorflow::tf$keras$utils$get_file(
     targetFileName, url, cache_subdir = antsxnetCacheDirectory )
   return( targetFileNamePath )


### PR DESCRIPTION
Keras will not use the cache if it is not writeable, which breaks
caches inside singularity containers or other read-only locations